### PR TITLE
Fee plan visibility

### DIFF
--- a/app/views/people/new.html.erb
+++ b/app/views/people/new.html.erb
@@ -43,7 +43,7 @@
 	  <div class="control-group">
       <%= f.label "Fee Plan", :class => 'control-label' %>
       <div class="controls">
-        <% FeePlan.order(&:name).each do |plan| %>
+        <% FeePlan.where(available: true).order(&:name).each do |plan| %>
           <%= f.radio_button(:fee_plan_id, plan.id, label: plan.name) %>
           <p><%= plan.description %></p>
           <ul>

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -504,6 +504,7 @@ end
       field :fixed_transaction_fees
       field :percent_transaction_fees
       field :recurring_fees
+      field :available
 
   end
 

--- a/db/migrate/20140528175903_add_availability_flag_to_fee_plans.rb
+++ b/db/migrate/20140528175903_add_availability_flag_to_fee_plans.rb
@@ -1,0 +1,5 @@
+class AddAvailabilityFlagToFeePlans < ActiveRecord::Migration
+  def change
+    add_column :fee_plans, :available, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140403075352) do
+ActiveRecord::Schema.define(:version => 20140528175903) do
 
   create_table "accounts", :force => true do |t|
     t.string   "name"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(:version => 20140403075352) do
     t.decimal  "earned",          :precision => 8, :scale => 2, :default => 0.0
     t.decimal  "reserve_percent", :precision => 8, :scale => 7, :default => 0.0
     t.boolean  "reserve",                                       :default => false
+    t.decimal  "rollover_charge",                               :default => 0.0
   end
 
   create_table "activities", :force => true do |t|
@@ -264,10 +265,11 @@ ActiveRecord::Schema.define(:version => 20140403075352) do
   end
 
   create_table "fee_plans", :force => true do |t|
-    t.string   "name",        :limit => 100, :null => false
+    t.string   "name",        :limit => 100,                    :null => false
     t.string   "description"
-    t.datetime "created_at",                 :null => false
-    t.datetime "updated_at",                 :null => false
+    t.datetime "created_at",                                    :null => false
+    t.datetime "updated_at",                                    :null => false
+    t.boolean  "available",                  :default => false
   end
 
   create_table "feed_posts", :force => true do |t|


### PR DESCRIPTION
Adds an 'available' flag to fee plans, and only available plans are shown on the signup page.

Fixes #22
