### PR TITLE
Open Offers - Filter deactivated accounts

### DIFF
--- a/app/controllers/public_offers_controller.rb
+++ b/app/controllers/public_offers_controller.rb
@@ -5,7 +5,11 @@ class PublicOffersController < ApplicationController
   skip_before_filter :require_activation
 
   def index
-    @offers = Offer.active.order('offers.id desc')
+    @offers = Offer
+                .active
+                .includes(:person)
+                .where(people: { deactivated: false })
+                .order('offers.id desc')
     @offers = @offers.paginate(page: params[:page], per_page: 100)
   end
 


### PR DESCRIPTION
Open offers were showing offers from deactivated accounts. This filters such results.

Fixes: #219 